### PR TITLE
Add YouTube service wrapper class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.sps</groupId>
@@ -32,6 +32,26 @@
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-youtube</artifactId>
+      <version>v3-rev20200526-1.30.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-servlet</artifactId>
+      <version>1.30.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-jetty</artifactId>
+      <version>1.23.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/google/sps/servlets/YouTubeServiceWrapper.java
+++ b/src/main/java/com/google/sps/servlets/YouTubeServiceWrapper.java
@@ -1,0 +1,60 @@
+package com.google.sps.servlets;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.ChannelListResponse;
+import com.google.api.services.youtube.model.CommentThread;
+import com.google.api.services.youtube.model.CommentThreadListResponse;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class YouTubeServiceWrapper {
+    private final String DEVELOPER_KEY = "DEV_KEY";
+    private final Credential CREDENTIAL;
+    private final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+
+    public YouTubeServiceWrapper(Credential credential){
+        this.CREDENTIAL = credential;
+    }
+
+    private YouTube getService() throws GeneralSecurityException, IOException{
+        if (CREDENTIAL == null){
+            final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+            return new YouTube.Builder(httpTransport, JSON_FACTORY, null).build();
+        }
+        return new YouTube.Builder(CREDENTIAL.getTransport(), CREDENTIAL.getJsonFactory(), CREDENTIAL).build();
+    }
+
+    // This is an example of an API call that does not requires OAuth2.0
+    public List<String> getCommentsFromVideoID (String videoID) throws GeneralSecurityException, IOException {
+        YouTube youtubeService = getService();
+        YouTube.CommentThreads.List req = youtubeService.commentThreads().list(Collections.singletonList("snippet"));
+        CommentThreadListResponse res = req.setKey(DEVELOPER_KEY).setVideoId(videoID).execute();
+
+        List<String> ret = new ArrayList<>();
+        for (CommentThread commentThread :res.getItems()){
+            String commentContent = commentThread.getSnippet().getTopLevelComment().getSnippet().getTextDisplay();
+            ret.add(commentContent);
+        }
+        return ret;
+    }
+
+    // This is an example of an API call that requires OAuth2.0. The credential will be generated in YTAuthServlet.
+    public String getMyChannelDetail() throws GeneralSecurityException, IOException {
+        YouTube youtubeService = getService();
+        YouTube.Channels.List req = youtubeService.channels().list(Arrays.asList("snippet", "contentDetails"));
+        ChannelListResponse res = req.setMine(true).execute();
+        return res.getItems().toString();
+    }
+
+    // More functions can be added here.
+}


### PR DESCRIPTION
This class collects methods that call YouTube API and format the responses into string, list of strings or other java objects. This helps avoid interacting with the API in the servlets (no need to import all the api objects in the servlet files). 

A credential is needed to create a YouTubeServiceWrapper object. Depending on which credential level is required to make the API call, the credential can be: 

* `null`, if the API query does not need user authorization. 
* a `com.google.api.client.auth.oauth2.Credential` object that is generated from the OAuth flow, if the query need some level of user authorization. 

`DEVELOPER_KEY` can be generated in the cloud console (API&Services>Credentials>API Keys). 