### PR TITLE
Add /yt servlet

### DIFF
--- a/src/main/java/com/google/sps/servlets/YouTubeServlet.java
+++ b/src/main/java/com/google/sps/servlets/YouTubeServlet.java
@@ -1,0 +1,28 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/yt")
+public class YouTubeServlet extends HttpServlet {
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Queries that does not require OAuth2.0 can be called this way
+        String id = "kNovwPIWr3Q"; // <- sample video id
+        List<String> ret = null;
+        try {
+            ret = new YouTubeServiceWrapper(null).getCommentsFromVideoID(id);
+        } catch (GeneralSecurityException e) {
+            e.printStackTrace();
+        }
+
+        response.setContentType("application/json;");
+        response.getWriter().println(ret);
+    }
+}


### PR DESCRIPTION
This is a skeleton file of the /yt servlet. It fetches first 20 comments of a specific video and prints them out to /yt page. Sentiment analysis, formatting the response into a json for the front end to parse and very likely changing url are needed. 

How to test: When you checkout the "yt-comment" branch, insert the `DEV_KEY`, run the test server and go to /yt, it should print out the first 20 comments of the sample video (without requiring any authorization).