### PR TITLE
Fetch caption in backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,18 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/sps/servlets/Caption.java
+++ b/src/main/java/com/google/sps/servlets/Caption.java
@@ -10,7 +10,7 @@ import org.xml.sax.SAXException;
 
 public class Caption {
   /*
-   * Usage: String caption = new Caption(new CaptionService()).getCaptionFromID("abcdefg");
+   * Usage: String caption = new Caption().getCaptionFromID("abcdefg");
    * 
    * Return null if not found.
    */

--- a/src/main/java/com/google/sps/servlets/Caption.java
+++ b/src/main/java/com/google/sps/servlets/Caption.java
@@ -1,0 +1,46 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class Caption {
+  /*
+   * Usage: String caption = new Caption(new CaptionService()).getCaptionFromID("abcdefg");
+   * 
+   * Return null if not found.
+   */
+
+  private CaptionService captionService = new CaptionService();
+  private DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+
+  public String getCaptionFromId(String videoId) {
+    // BCP47 language tags
+    final String[] languages = {"en", "en-US", "en-GB", "en-AU", "en-IE", "en-ZA"};
+    for (String language : languages) {
+      try {
+        return parseXmlFromStream(captionService.fetchStream(videoId, language));
+      } catch (SAXException | ParserConfigurationException | IOException
+          | IllegalArgumentException e) {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  private String parseXmlFromStream(InputStream inputStream)
+      throws SAXException, ParserConfigurationException, IOException, IllegalArgumentException {
+    Document doc = docBuilderFactory.newDocumentBuilder().parse(inputStream);
+    NodeList textDom = doc.getElementsByTagName("text");
+    StringBuilder caption = new StringBuilder();
+    for (int i = 0; i < textDom.getLength(); i++) {
+      caption.append(textDom.item(i).getFirstChild().getNodeValue());
+      caption.append(" ");
+    }
+    return caption.toString().trim();
+  }
+}

--- a/src/main/java/com/google/sps/servlets/CaptionService.java
+++ b/src/main/java/com/google/sps/servlets/CaptionService.java
@@ -2,14 +2,12 @@ package com.google.sps.servlets;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 public class CaptionService {
-  public InputStream fetchStream(String videoId, String language)
-      throws MalformedURLException, IOException {
+  public InputStream fetchStream(String videoId, String language) throws IOException {
     if (videoId == null) {
-      throw new MalformedURLException();
+      throw new IllegalArgumentException("Video ID must be a non-null string.");
     }
     return new URL(
         String.format("http://video.google.com/timedtext?lang=%s&v=%s", language, videoId))

--- a/src/main/java/com/google/sps/servlets/CaptionService.java
+++ b/src/main/java/com/google/sps/servlets/CaptionService.java
@@ -1,0 +1,18 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class CaptionService {
+  public InputStream fetchStream(String videoId, String language)
+      throws MalformedURLException, IOException {
+    if (videoId == null) {
+      throw new MalformedURLException();
+    }
+    return new URL(
+        String.format("http://video.google.com/timedtext?lang=%s&v=%s", language, videoId))
+            .openStream();
+  }
+}

--- a/src/test/java/com/google/sps/servlets/CaptionTest.java
+++ b/src/test/java/com/google/sps/servlets/CaptionTest.java
@@ -1,0 +1,125 @@
+package com.google.sps.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public final class CaptionTest {
+  @Mock
+  private CaptionService captionServiceMock;
+
+  @InjectMocks
+  private Caption caption;
+
+  final private String PROPER_XML = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><transcript>"
+      + "<text start=\"4.029\" dur=\"5.401\">line1</text>"
+      + "<text start=\"9.43\" dur=\"5.06\">line2</text>"
+      + "<text start=\"14.49\" dur=\"5.03\">line3</text>" + "</transcript>";
+
+  final private String PROPER_XML_CAPTION = "line1 line2 line3";
+
+  final private String BAD_XML = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><transcript>"
+      + "<text start=\"4.029\" dur=\"5.401\">line1</text>";
+
+  final private String VIDEO_ID = "sampleId";
+
+  final private String LANG_EN = "en";
+
+  final private String LANG_EN_GB = "en-GB";
+
+  @Before
+  public void init() {
+    caption = new Caption();
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void properXmlReturnsConcatenatedString() throws IOException {
+    InputStream stream = new ByteArrayInputStream(PROPER_XML.getBytes());
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertEquals(PROPER_XML_CAPTION, actual);
+  }
+
+  @Test
+  public void badXmlReturnsNullIgnoringSAXException() throws IOException {
+    InputStream stream = new ByteArrayInputStream(BAD_XML.getBytes());
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertNull(actual);
+  }
+
+  @Test
+  public void nonDefaultLanguageReturnsConcatenatedString() throws IOException {
+    InputStream stream = new ByteArrayInputStream(PROPER_XML.getBytes());
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), eq(LANG_EN_GB))).thenReturn(stream);
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), not(eq(LANG_EN_GB))))
+        .thenThrow(new IOException());
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertEquals(PROPER_XML_CAPTION, actual);
+  }
+
+  @Test
+  public void nullIdReturnsNullIgnoringIOException() throws IOException {
+    when(captionServiceMock.fetchStream(eq(null), anyString())).thenThrow(new IOException());
+
+    String actual = caption.getCaptionFromId(null);
+
+    assertNull(actual);
+  }
+
+  @Test
+  public void badIDReturnsNullIgnoringIOException() throws IOException {
+    when(captionServiceMock.fetchStream(anyString(), anyString())).thenThrow(new IOException());
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertNull(actual);
+  }
+
+  @Test
+  public void nullStreamReturnsNullIgnoringIllegalArgumentException() throws IOException {
+    when(captionServiceMock.fetchStream(anyString(), anyString())).thenReturn(null);
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertNull(actual);
+  }
+
+  @Test
+  public void ignoreParserConfigurationException() throws ParserConfigurationException {
+    DocumentBuilderFactory docBuilderFactory = mock(DocumentBuilderFactory.class);
+    when(docBuilderFactory.newDocumentBuilder()).thenThrow(new ParserConfigurationException());
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertNull(actual);
+  }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
To avoid transferring long strings from the front end to the back end for sentiment analysis, the `Caption` class and the `CaptionService` class are implemented to fetch English captions (if exists) given a valid video id. 

`CaptionService` class can open a `HttpUrlConnection` and returns an input stream, then the `Caption` class processes the input stream and returns a caption string, ready for sentiment analysis. 

The endpoint is the `Caption.getCaptionFromId()` function: this can be called in a servlet which is exposed to the front end. 

The `Caption` class is unit-tested by mocking its dependency `CaptionService`. `CaptionService` class is not unit-tested because it opens actual http connections (I did manually tested the whole flow and it worked). Any suggestion on how to test the `CaptionService` class is appreciated. 