### PR TITLE
Post a comment in the front end

### DIFF
--- a/src/main/webapp/scripts/post-comment.js
+++ b/src/main/webapp/scripts/post-comment.js
@@ -1,0 +1,27 @@
+function postVideoComment(videoId, commentText) {
+    return new Promise((resolve, reject) => {
+        gapi.client.request(buildRequestBody(videoId, commentText))
+            .then(res => res.json)
+            .then(data => resolve(data))
+            .catch(err => reject(new Error(err.result.error.message)));
+    });
+}
+
+function buildRequestBody(videoId, commentContent) {
+    return {
+        'path': '/youtube/v3/commentThreads?part=snippet',
+        'method': 'POST',
+        'body': {
+            'snippet': {
+                'videoId': videoId,
+                'topLevelComment': {
+                    'snippet': {
+                        'textOriginal': commentContent
+                    },
+                },
+            },
+        },
+    };
+}
+
+export { postVideoComment };

--- a/src/main/webapp/scripts/tests/comment-post-test.js
+++ b/src/main/webapp/scripts/tests/comment-post-test.js
@@ -1,0 +1,95 @@
+import { postVideoComment } from '/scripts/post-comment.js';
+
+const VIDEO_ID = 'sample video id';
+const COMMENT_TEXT = 'sample comment';
+
+QUnit.module('Post a comment via YouTube API', {
+    beforeEach: () => {
+        gapi = new CustomGapi();
+        sinon.stub(gapi.client, 'request');
+    },
+    afterEach: () => { gapi.client.request.restore(); },
+});
+
+QUnit.test('Call API with correct request body', function (assert) {
+    const done = assert.async();
+
+    gapi.client.request.returns(Promise.resolve(new CustomResponse()));
+
+    postVideoComment(VIDEO_ID, COMMENT_TEXT)
+        .then(() => {
+            assert.deepEqual(gapi.client.request.getCall(0).args[0],
+                createExpectedRequestBody(VIDEO_ID, COMMENT_TEXT));
+            done();
+        });
+});
+
+QUnit.test('Relay the error with correct message', function (assert) {
+    const done = assert.async();
+    const errorMsg = 'error message';
+
+    gapi.client.request.returns(Promise.reject(new CustomError(errorMsg)));
+
+    postVideoComment(VIDEO_ID, COMMENT_TEXT)
+        .catch(error => {
+            assert.equal(error.message, errorMsg);
+            done();
+        });
+});
+
+QUnit.test('Successful post returns empty response', function (assert) {
+    const done = assert.async();
+    assert.expect(0);
+
+    gapi.client.request.returns(Promise.resolve(new CustomResponse()));
+
+    postVideoComment(VIDEO_ID, COMMENT_TEXT)
+        .then(() => {
+            done();
+        });
+});
+
+
+// Helper functions and classes
+
+class CustomResponse extends Response {
+    constructor() {
+        super();
+        this.json = {};
+    }
+}
+
+class CustomError extends Error {
+    constructor(msg) {
+        super();
+        this.result = { 'error': { 'message': msg, } };
+    }
+}
+
+class CustomGapi {
+    constructor() {
+        this.client = new CustomClient();
+    }
+}
+
+class CustomClient {
+    constructor() { }
+    request() { }
+}
+
+function createExpectedRequestBody(videoId, commentText) {
+    return {
+        'path': '/youtube/v3/commentThreads?part=snippet',
+        'method': 'POST',
+        'body': {
+            'snippet': {
+                'videoId': videoId,
+                'topLevelComment': {
+                    'snippet': {
+                        'textOriginal': commentText,
+                    },
+                },
+            },
+        },
+    };
+}

--- a/src/main/webapp/tests.html
+++ b/src/main/webapp/tests.html
@@ -16,5 +16,7 @@
   <script src="scripts/perspective-api-service.js"></script>
   <script src="scripts/classes/comment-class.js"></script>
   <script src="scripts/tests/perspective-test.js"></script>
+  <script src="https://apis.google.com/js/api.js"></script>
+  <script defer type="module" src="scripts/tests/comment-post-test.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR included a function in comments.js that makes a POST request to the YouTube server. It returns nothing if successful and an error if failed. 

* Use QUnit to test (tests.html)
* Use sinon.js to stub responses