### PR TITLE
OAuth2 and post comment in the front end

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -35,6 +35,17 @@
   <script src="scripts/perspective.js"></script>
   <script src="scripts/perspective-api-service.js"></script>
   <script src="scripts/classes/comment-class.js"></script>
-  </script>
+  
+  <div>
+    <p>Post a comment to </p>
+    <a href="https://www.youtube.com/watch?v=gjKpAAezWQA">this video</a>
+    <button id="authorize-button">Authorize</button>
+    <div id="comment-button-container"></div>
+    <div id="result-text"></div>
+  
+    <script defer type="module" src="scripts/controller-auth.js"></script>
+    <script src="https://apis.google.com/js/api.js"></script>
+  </div>
+    
 </body>
 </html>

--- a/src/main/webapp/scripts/controller-auth.js
+++ b/src/main/webapp/scripts/controller-auth.js
@@ -62,4 +62,4 @@ function handleCommentClick(event) {
 handleClientLoad();
 
 // For testing purpose
-export { initClient, handleAuthClick, handleSignoutClick, handleCommentClick };
+export { initClient };

--- a/src/main/webapp/scripts/controller-auth.js
+++ b/src/main/webapp/scripts/controller-auth.js
@@ -1,5 +1,5 @@
 import { postVideoComment } from '/scripts/post-comment.js';
-import { videoId, commentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus } from '/scripts/view.js';
+import { videoId, postCommentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus } from '/scripts/view.js';
 
 /** API key provied by GCP to authenticate the client */
 const apiKey = '';

--- a/src/main/webapp/scripts/controller-auth.js
+++ b/src/main/webapp/scripts/controller-auth.js
@@ -1,15 +1,24 @@
 import { postVideoComment } from '/scripts/post-comment.js';
-import { videoId, commentElement, failedInit, successfulApiCallback, failedApiCallback, updateSigninStatus } from '/scripts/view.js';
+import { videoId, commentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus } from '/scripts/view.js';
 
+/** API key provied by GCP to authenticate the client */
 const apiKey = '';
+/** client ID provied by GCP to identify the client */
 const clientId = '';
+/** discovery docs used to identify API endpoints */
 const discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest'];
+/** OAuth2 scope required to post a comment */
 const scope = 'https://www.googleapis.com/auth/youtube.force-ssl';
 
+/** Load the client from Google API oauth2.0 JS library */
 function handleClientLoad() {
   gapi.load('client:auth2', initClient);
 }
 
+/** 
+ * Initialize the client with appropiate fields.
+ * And listen for changed in the signin status.
+ */
 function initClient() {
   gapi.client.init({
     apiKey,
@@ -26,17 +35,23 @@ function initClient() {
       updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get(),
         handleAuthClick, handleSignoutClick, handleCommentClick);
     })
-    .catch(failedInit);
+    .catch(failedInitCallback);
 }
 
+/** 
+ * Handler that initiates the authorization flow with a popup.
+ * The user only needs to authorize the site once.
+ */
 function handleAuthClick(event) {
   gapi.auth2.getAuthInstance().signIn();
 }
 
+/** Handler that quietly signs the user out, but does not revoke the authorization */
 function handleSignoutClick(event) {
   gapi.auth2.getAuthInstance().signOut();
 }
 
+/** Handler that posts the comment and processes the result */
 function handleCommentClick(event) {
   postVideoComment(videoId, postCommentElement.value)
     .then(successfulApiCallback)

--- a/src/main/webapp/scripts/controller-auth.js
+++ b/src/main/webapp/scripts/controller-auth.js
@@ -1,0 +1,47 @@
+import { postVideoComment } from '/scripts/post-comment.js';
+import { videoId, commentElement, failedInit, successfulApiCallback, failedApiCallback, updateSigninStatus } from '/scripts/view.js';
+
+const apiKey = '';
+const clientId = '';
+const discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest'];
+const scope = 'https://www.googleapis.com/auth/youtube.force-ssl';
+
+function handleClientLoad() {
+  gapi.load('client:auth2', initClient);
+}
+
+function initClient() {
+  gapi.client.init({
+    apiKey,
+    discoveryDocs,
+    clientId,
+    scope
+  })
+    .then(function () {
+      // Listen for sign-in state changes.
+      gapi.auth2.getAuthInstance().isSignedIn.listen((isSignedIn) =>
+        updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, handleCommentClick));
+
+      // Handle the initial sign-in state.
+      updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get(),
+        handleAuthClick, handleSignoutClick, handleCommentClick);
+    })
+    .catch(failedInit);
+}
+
+function handleAuthClick(event) {
+  gapi.auth2.getAuthInstance().signIn();
+}
+
+function handleSignoutClick(event) {
+  gapi.auth2.getAuthInstance().signOut();
+}
+
+function handleCommentClick(event) {
+  postVideoComment(videoId, postCommentElement.value)
+    .then(successfulApiCallback)
+    .catch(failedApiCallback);
+}
+
+// Entry point
+handleClientLoad();

--- a/src/main/webapp/scripts/controller-auth.js
+++ b/src/main/webapp/scripts/controller-auth.js
@@ -20,7 +20,7 @@ function handleClientLoad() {
  * And listen for changed in the signin status.
  */
 function initClient() {
-  gapi.client.init({
+  return gapi.client.init({
     apiKey,
     discoveryDocs,
     clientId,
@@ -53,10 +53,13 @@ function handleSignoutClick(event) {
 
 /** Handler that posts the comment and processes the result */
 function handleCommentClick(event) {
-  postVideoComment(videoId, postCommentElement.value)
+  return postVideoComment(videoId, postCommentElement.value)
     .then(successfulApiCallback)
     .catch(failedApiCallback);
 }
 
 // Entry point
 handleClientLoad();
+
+// For testing purpose
+export { initClient, handleAuthClick, handleSignoutClick, handleCommentClick };

--- a/src/main/webapp/scripts/post-comment.js
+++ b/src/main/webapp/scripts/post-comment.js
@@ -20,7 +20,7 @@ function postVideoComment(videoId, commentText) {
  * @private
  * @param {String} videoId 
  * @param {String} commentContent 
- * @returns {json} request body for a POST comment request by video ID
+ * @returns {Object} request body for a POST comment request by video ID
  */
 function buildRequestBody(videoId, commentContent) {
     return {

--- a/src/main/webapp/scripts/post-comment.js
+++ b/src/main/webapp/scripts/post-comment.js
@@ -1,3 +1,11 @@
+/**
+ * Post a video comment by making a POST request to YouTube Data API.
+ * @exports
+ * @param {String} videoId 
+ * @param {String} commentText 
+ * @returns {String} empty string if successful post
+ * @throws {Error} with error message if failed post
+ */
 function postVideoComment(videoId, commentText) {
     return new Promise((resolve, reject) => {
         gapi.client.request(buildRequestBody(videoId, commentText))
@@ -7,6 +15,13 @@ function postVideoComment(videoId, commentText) {
     });
 }
 
+/**
+ * Build a request body expected by the API.
+ * @private
+ * @param {String} videoId 
+ * @param {String} commentContent 
+ * @returns {json} request body for a POST comment request by video ID
+ */
 function buildRequestBody(videoId, commentContent) {
     return {
         'path': '/youtube/v3/commentThreads?part=snippet',

--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -11,8 +11,7 @@ QUnit.module('Authorization controller', {
 });
 
 QUnit.test('When init fails, displays the authorization button and the error message', async function (assert) {
-  const errorMsg = 'error message';
-  sinon.stub(gapi.client, 'init').returns(Promise.reject(new Error(errorMsg)));
+  sinon.stub(gapi.client, 'init').returns(Promise.reject(new Error()));
 
   await controller.initClient();
 
@@ -26,8 +25,7 @@ QUnit.test('When signed in, there should be sign-out and comment buttons', async
   await controller.initClient();
 
   assert.dom('#authorize-button').hasProperty('innerText', 'Sign out');
-  assert.dom('#authorize-button').hasProperty('onclick', controller.handleSignoutClick);
-  assert.dom('#comment-button').hasProperty('onclick', controller.handleCommentClick);
+  assert.dom('#comment-button').exists();
 });
 
 QUnit.test('When signed out, there should be an authorization button', async function (assert) {
@@ -37,27 +35,42 @@ QUnit.test('When signed out, there should be an authorization button', async fun
   await controller.initClient();
 
   assert.dom('#authorize-button').hasProperty('innerText', 'Authorize');
-  assert.dom('#authorize-button').hasProperty('onclick', controller.handleAuthClick);
   assert.dom('#comment-button').doesNotExist();
 });
 
 QUnit.test('When postVideoComment fails, the error message should be displayed', async function (assert) {
+  sinon.stub(gapi.client, 'init').returns(Promise.resolve());
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(fakeGetAuthInstance(true));
   const errorMsg = 'error message';
-  sinon.stub(gapi.client, 'request');
-  gapi.client.request.returns(Promise.reject(new CustomError(errorMsg)));
+  sinon.stub(gapi.client, 'request').returns(Promise.reject(new CustomError(errorMsg)));
 
-  await controller.handleCommentClick();
+  await controller.initClient();
+
+  const postCommentButton = document.getElementById('comment-button');
+  const temp = postCommentButton.onclick;
+  postCommentButton.onclick = () => {
+    return Promise.resolve(temp());
+  };
+  await postCommentButton.onclick();
 
   assert.dom('#result-text').hasProperty('innerText', `Error: ${errorMsg}`);
 });
 
 QUnit.test('When postVideoComment succeeds, the success message should be displayed', async function (assert) {
-  sinon.stub(gapi.client, 'request');
-  gapi.client.request.returns(Promise.resolve(new CustomResponse()));
+  sinon.stub(gapi.client, 'init').returns(Promise.resolve());
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(fakeGetAuthInstance(true));
+  sinon.stub(gapi.client, 'request').returns(Promise.resolve(new CustomResponse()));
 
-  await controller.handleCommentClick();
+  await controller.initClient();
 
-  assert.dom('#result-text').hasProperty('innerText', `Successful`);
+  const postCommentButton = document.getElementById('comment-button');
+  const temp = postCommentButton.onclick;
+  postCommentButton.onclick = () => {
+    return Promise.resolve(temp());
+  };
+  await postCommentButton.onclick();
+
+  assert.dom('#result-text').hasProperty('innerText', 'Successful');
 });
 
 

--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -1,4 +1,3 @@
-import * as view from '/scripts/view.js';
 import * as controller from '/scripts/controller-auth.js';
 
 // Test (controller-auth.js and) view.js
@@ -22,14 +21,7 @@ QUnit.test('When init fails, displays the authorization button and the error mes
 
 QUnit.test('When signed in, there should be sign-out and comment buttons', async function (assert) {
   sinon.stub(gapi.client, 'init').returns(Promise.resolve());
-  sinon.stub(gapi.auth2, 'getAuthInstance').returns(
-    {
-      'isSignedIn':
-      {
-        'get': () => { return true; },
-        'listen': () => { },
-      }
-    });
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(fakeGetAuthInstance(true));
 
   await controller.initClient();
 
@@ -40,14 +32,7 @@ QUnit.test('When signed in, there should be sign-out and comment buttons', async
 
 QUnit.test('When signed out, there should be an authorization button', async function (assert) {
   sinon.stub(gapi.client, 'init').returns(Promise.resolve());
-  sinon.stub(gapi.auth2, 'getAuthInstance').returns(
-    {
-      'isSignedIn':
-      {
-        'get': () => { return false; },
-        'listen': () => { },
-      }
-    });
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(fakeGetAuthInstance(false));
 
   await controller.initClient();
 
@@ -108,4 +93,14 @@ class CustomError extends Error {
     super();
     this.result = { 'error': { 'message': msg, } };
   }
+}
+
+function fakeGetAuthInstance(isSignedIn) {
+  return {
+    'isSignedIn':
+    {
+      'get': () => { return isSignedIn; },
+      'listen': () => { },
+    }
+  };
 }

--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -20,25 +20,39 @@ QUnit.test('When init fails, displays the authorization button and the error mes
   assert.dom('#result-text').hasProperty('innerText', 'Failed to initialize client');
 });
 
-QUnit.test('When signed in, there should be sign-out and comment buttons', function (assert) {
-  const fakeSignOut = sinon.fake();
-  const fakeHandleCommentClick = sinon.fake();
+QUnit.test('When signed in, there should be sign-out and comment buttons', async function (assert) {
+  sinon.stub(gapi.client, 'init').returns(Promise.resolve());
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(
+    {
+      'isSignedIn':
+      {
+        'get': () => { return true; },
+        'listen': () => { },
+      }
+    });
 
-  view.updateSigninStatus(true, () => { }, fakeSignOut, fakeHandleCommentClick);
+  await controller.initClient();
 
   assert.dom('#authorize-button').hasProperty('innerText', 'Sign out');
-  assert.dom('#authorize-button').hasProperty('onclick', fakeSignOut);
-  assert.dom('#comment-button').hasProperty('onclick', fakeHandleCommentClick);
+  assert.dom('#authorize-button').hasProperty('onclick', controller.handleSignoutClick);
+  assert.dom('#comment-button').hasProperty('onclick', controller.handleCommentClick);
 });
 
-QUnit.test('When signed out, there should be an authorization button', function (assert) {
-  const fakeAuth = sinon.fake();
-  const fakeHandleCommentClick = sinon.fake();
+QUnit.test('When signed out, there should be an authorization button', async function (assert) {
+  sinon.stub(gapi.client, 'init').returns(Promise.resolve());
+  sinon.stub(gapi.auth2, 'getAuthInstance').returns(
+    {
+      'isSignedIn':
+      {
+        'get': () => { return false; },
+        'listen': () => { },
+      }
+    });
 
-  view.updateSigninStatus(false, fakeAuth, () => { }, fakeHandleCommentClick);
+  await controller.initClient();
 
   assert.dom('#authorize-button').hasProperty('innerText', 'Authorize');
-  assert.dom('#authorize-button').hasProperty('onclick', fakeAuth);
+  assert.dom('#authorize-button').hasProperty('onclick', controller.handleAuthClick);
   assert.dom('#comment-button').doesNotExist();
 });
 
@@ -67,7 +81,13 @@ QUnit.test('When postVideoComment succeeds, the success message should be displa
 class CustomGapi {
   constructor() {
     this.client = new CustomClient();
+    this.auth2 = new Auth2();
   }
+}
+
+class Auth2 {
+  constructor() { }
+  getAuthInstance() { }
 }
 
 class CustomClient {

--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -1,0 +1,91 @@
+import * as view from '/scripts/view.js';
+import * as controller from '/scripts/controller-auth.js';
+
+// Test (controller-auth.js and) view.js
+QUnit.module('Authorization controller', {
+  beforeEach: () => {
+    gapi = new CustomGapi();
+  },
+  afterEach: () => {
+    sinon.restore();
+  }
+});
+
+QUnit.test('When init fails, displays the authorization button and the error message', async function (assert) {
+  const errorMsg = 'error message';
+  sinon.stub(gapi.client, 'init').returns(Promise.reject(new Error(errorMsg)));
+
+  await controller.initClient();
+
+  assert.dom('#result-text').hasProperty('innerText', 'Failed to initialize client');
+});
+
+QUnit.test('When signed in, there should be sign-out and comment buttons', function (assert) {
+  const fakeSignOut = sinon.fake();
+  const fakeHandleCommentClick = sinon.fake();
+
+  view.updateSigninStatus(true, () => { }, fakeSignOut, fakeHandleCommentClick);
+
+  assert.dom('#authorize-button').hasProperty('innerText', 'Sign out');
+  assert.dom('#authorize-button').hasProperty('onclick', fakeSignOut);
+  assert.dom('#comment-button').hasProperty('onclick', fakeHandleCommentClick);
+});
+
+QUnit.test('When signed out, there should be an authorization button', function (assert) {
+  const fakeAuth = sinon.fake();
+  const fakeHandleCommentClick = sinon.fake();
+
+  view.updateSigninStatus(false, fakeAuth, () => { }, fakeHandleCommentClick);
+
+  assert.dom('#authorize-button').hasProperty('innerText', 'Authorize');
+  assert.dom('#authorize-button').hasProperty('onclick', fakeAuth);
+  assert.dom('#comment-button').doesNotExist();
+});
+
+QUnit.test('When postVideoComment fails, the error message should be displayed', async function (assert) {
+  const errorMsg = 'error message';
+  sinon.stub(gapi.client, 'request');
+  gapi.client.request.returns(Promise.reject(new CustomError(errorMsg)));
+
+  await controller.handleCommentClick();
+
+  assert.dom('#result-text').hasProperty('innerText', `Error: ${errorMsg}`);
+});
+
+QUnit.test('When postVideoComment succeeds, the success message should be displayed', async function (assert) {
+  sinon.stub(gapi.client, 'request');
+  gapi.client.request.returns(Promise.resolve(new CustomResponse()));
+
+  await controller.handleCommentClick();
+
+  assert.dom('#result-text').hasProperty('innerText', `Successful`);
+});
+
+
+
+// Helper functions and classes
+class CustomGapi {
+  constructor() {
+    this.client = new CustomClient();
+  }
+}
+
+class CustomClient {
+  constructor() { }
+  request() { }
+  init() { }
+}
+
+class CustomResponse extends Response {
+  constructor() {
+    super();
+    this.json = {};
+  }
+}
+
+class CustomError extends Error {
+  constructor(msg) {
+    super();
+    this.result = { 'error': { 'message': msg, } };
+  }
+}

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -5,10 +5,10 @@ const authorizeButton = document.getElementById('authorize-button');
 const videoId = 'gjKpAAezWQA';
 
 /** Textbox that allows user to input comments */
-const commentElement = document.getElementById('comment-text');
+const postCommentElement = document.getElementById('comment-text');
 
 /** Container that holds the success/error message */
-const resultContainer = document.getElementById('result-text');
+const postResultContainer = document.getElementById('result-text');
 
 /**
  * Overwrite the innerText of a DOM element identified by its Id.
@@ -54,16 +54,16 @@ function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, han
  */
 function failedInitCallback(err) {
     console.error('init error', err)
-    updateDom('Failed to initialize client', resultContainer)
+    updateDom('Failed to initialize client', postResultContainer)
 }
 
 /**
  * Display 'successful' when the comment has been posted.
  * @exports
- * @param {*} data 
+ * @param {*} data content is ignored
  */
 function successfulApiCallback(data) {
-    updateDom('successful', resultContainer);
+    updateDom('successful', postResultContainer);
 }
 
 /**
@@ -73,7 +73,7 @@ function successfulApiCallback(data) {
  */
 function failedApiCallback(err) {
     console.error('execution error ', err);
-    updateDom(err, resultContainer);
+    updateDom(err, postResultContainer);
 }
 
-export { videoId, commentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus };
+export { videoId, postCommentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus };

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -1,0 +1,45 @@
+function updateDom(text, containerDOM) {
+    while (containerDOM.firstChild) {
+        containerDOM.removeChild(containerDOM.firstChild);
+    }
+    containerDOM.innerText = text;
+}
+
+const authorizeButton = document.getElementById('authorize-button');
+
+const videoId = 'gjKpAAezWQA';
+const commentElement = document.getElementById('comment-text');
+const resultContainer = document.getElementById('result-text');
+
+function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, handleCommentClick) {
+    if (isSignedIn) {
+        updateDom('Sign out', authorizeButton)
+        authorizeButton.onclick = handleSignoutClick;
+        const commentButton = document.createElement('button');
+        document.getElementById('comment-button-container').appendChild(commentButton);
+        commentButton.id = 'comment-button';
+        commentButton.innerText = 'Post a comment';
+        commentButton.onclick = handleCommentClick;
+    } else {
+        updateDom('Authorize', authorizeButton);
+        authorizeButton.onclick = handleAuthClick;
+        const commentButton = document.getElementById('comment-button');
+        commentButton && commentButton.remove();
+    }
+}
+
+function failedInit(err) {
+    console.error('init error', err)
+    updateDom('Failed to initialize client', resultContainer)
+}
+
+function successfulApiCallback(data) {
+    updateDom('successful', resultContainer);
+}
+
+function failedApiCallback(err) {
+    console.error('execution error ', err);
+    updateDom(err, resultContainer);
+}
+
+export { videoId, commentElement, resultContainer, failedInit, successfulApiCallback, failedApiCallback, updateSigninStatus };

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -53,8 +53,8 @@ function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, han
  * @param {Error} err 
  */
 function failedInitCallback(err) {
-    console.error('init error', err)
-    updateDom('Failed to initialize client', postResultContainer)
+    console.error('init error', err);
+    updateDom('Failed to initialize client', postResultContainer);
 }
 
 /**
@@ -63,7 +63,7 @@ function failedInitCallback(err) {
  * @param {*} data content is ignored
  */
 function successfulApiCallback(data) {
-    updateDom('successful', postResultContainer);
+    updateDom('Successful', postResultContainer);
 }
 
 /**

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -1,3 +1,20 @@
+/** Button that triggers authorization/sign out flow */
+const authorizeButton = document.getElementById('authorize-button');
+
+/** Hardcoded test video Id that the comment will be posted to */
+const videoId = 'gjKpAAezWQA';
+
+/** Textbox that allows user to input comments */
+const commentElement = document.getElementById('comment-text');
+
+/** Container that holds the success/error message */
+const resultContainer = document.getElementById('result-text');
+
+/**
+ * Overwrite the innerText of a DOM element identified by its Id.
+ * @param {String} text 
+ * @param {String} containerDOM 
+ */
 function updateDom(text, containerDOM) {
     while (containerDOM.firstChild) {
         containerDOM.removeChild(containerDOM.firstChild);
@@ -5,12 +22,14 @@ function updateDom(text, containerDOM) {
     containerDOM.innerText = text;
 }
 
-const authorizeButton = document.getElementById('authorize-button');
-
-const videoId = 'gjKpAAezWQA';
-const commentElement = document.getElementById('comment-text');
-const resultContainer = document.getElementById('result-text');
-
+/**
+ * Modify the UI and link handle functions depending on the sign in status.
+ * @exports
+ * @param {Boolean} isSignedIn 
+ * @param {Function} handleAuthClick 
+ * @param {Function} handleSignoutClick 
+ * @param {Function} handleCommentClick 
+ */
 function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, handleCommentClick) {
     if (isSignedIn) {
         updateDom('Sign out', authorizeButton)
@@ -28,18 +47,33 @@ function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, han
     }
 }
 
-function failedInit(err) {
+/**
+ * Error handler when the Google API client fails to load.
+ * @exports
+ * @param {Error} err 
+ */
+function failedInitCallback(err) {
     console.error('init error', err)
     updateDom('Failed to initialize client', resultContainer)
 }
 
+/**
+ * Display 'successful' when the comment has been posted.
+ * @exports
+ * @param {*} data 
+ */
 function successfulApiCallback(data) {
     updateDom('successful', resultContainer);
 }
 
+/**
+ * Display the error message when the comment failed to be posted.
+ * @exports
+ * @param {Error} err
+ */
 function failedApiCallback(err) {
     console.error('execution error ', err);
     updateDom(err, resultContainer);
 }
 
-export { videoId, commentElement, resultContainer, failedInit, successfulApiCallback, failedApiCallback, updateSigninStatus };
+export { videoId, commentElement, failedInitCallback, successfulApiCallback, failedApiCallback, updateSigninStatus };

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -45,6 +45,7 @@ function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, han
         const commentButton = document.getElementById('comment-button');
         commentButton && commentButton.remove();
     }
+    updateDom('', postResultContainer);
 }
 
 /**

--- a/src/main/webapp/tests.html
+++ b/src/main/webapp/tests.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>QUnit Tests</title>
   <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.10.0.css">
 </head>
+
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
@@ -17,6 +19,18 @@
   <script src="scripts/classes/comment-class.js"></script>
   <script src="scripts/tests/perspective-test.js"></script>
   <script src="https://apis.google.com/js/api.js"></script>
+  <script src="https://unpkg.com/qunit-dom/dist/qunit-dom.js"></script>
   <script defer type="module" src="scripts/tests/comment-post-test.js"></script>
+  <script defer type="module" src="scripts/tests/controller-auth-test.js"></script>
+
+  <!-- Async tests seem to have some conflicts with qunit-fixture. 
+  Qunit may have restored the page before assertion happened. -->
+  <div id="content">
+    <textarea name="comment" id="comment-text"></textarea>
+    <button id="authorize-button">Authorize</button>
+    <div id="comment-button-container"></div>
+    <div id="result-text"></div>
+  </div>
 </body>
+
 </html>


### PR DESCRIPTION
This function allows user to authorize the site to post a comment on their behalf (the UI and other chores around #13 ). The comment text can be dynamically changed in the textarea in index.html. The target video is hard coded in view.js for now, and can be changed later. 

* Model: comments.js, View: view.js, Controller: controller_auth.js

### Screenshots
#### If the comment is successfully posted: 
![image](https://user-images.githubusercontent.com/31786519/87320377-de602d80-c4f8-11ea-83fb-936ad8008ee4.png)
#### Otherwise, the returned error message is displayed. 
![image](https://user-images.githubusercontent.com/31786519/87320298-c5577c80-c4f8-11ea-84ff-de8bc68c5e85.png)

If the "Sign out" and "Post a comment" buttons do not load, it is likely that the API key and clientId are missing in controller_auth.js