### PR TITLE
Fix bug with creating LanguageServiceClient instances.

### DIFF
--- a/src/main/java/com/google/sps/servlets/SentimentServlet.java
+++ b/src/main/java/com/google/sps/servlets/SentimentServlet.java
@@ -93,20 +93,14 @@ public class SentimentServlet extends HttpServlet {
   /**
    * Calculates sentiment score of text. The score is from -1 (negative) to +1 (positive).
    */ 
-  private Float calculateSentimentScore(String text) throws ApiException, IOException {
-    LanguageServiceClient languageService = createLanguageServiceClient();
+  private Float calculateSentimentScore(String text) throws ApiException {
     Document doc = Document.newBuilder()
         .setContent(text)
         .setTypeValue(Document.Type.PLAIN_TEXT_VALUE)
         .build();
     sentiment = languageService.analyzeSentiment(doc).getDocumentSentiment();
     Float score = new Float(sentiment.getScore());
-    languageService.close();
 
     return score;
-  }
-
-  public LanguageServiceClient createLanguageServiceClient() throws IOException {
-    return LanguageServiceClient.create();
   }
 }

--- a/src/main/java/com/google/sps/servlets/SentimentServlet.java
+++ b/src/main/java/com/google/sps/servlets/SentimentServlet.java
@@ -83,7 +83,8 @@ public class SentimentServlet extends HttpServlet {
   /**
    * Calculates sentiment score of text. The score is from -1 (negative) to +1 (positive).
    */ 
-  private Float calculateSentimentScore(String text) {
+  private Float calculateSentimentScore(String text) throws ApiException, IOException {
+    LanguageServiceClient languageService = createLanguageServiceClient();
     Document doc = Document.newBuilder()
         .setContent(text)
         .setTypeValue(Document.Type.PLAIN_TEXT_VALUE)
@@ -93,5 +94,9 @@ public class SentimentServlet extends HttpServlet {
     languageService.close();
 
     return score;
+  }
+
+  public LanguageServiceClient createLanguageServiceClient() throws IOException {
+    return LanguageServiceClient.create();
   }
 }

--- a/src/test/java/com/google/sps/SentimentServletTest.java
+++ b/src/test/java/com/google/sps/SentimentServletTest.java
@@ -47,14 +47,13 @@ public final class SentimentServletTest {
 
   @Spy HttpServletResponse responseSpy;
 
-  @Spy @InjectMocks SentimentServlet sentimentServlet;
+  @InjectMocks SentimentServlet sentimentServlet;
 
   @Before
   public void setUp() throws IOException, Exception {
     stringWriter = new StringWriter();
     writer = new PrintWriter(stringWriter);
     when(responseSpy.getWriter()).thenReturn(writer);
-    when(sentimentServlet.createLanguageServiceClient()).thenReturn(languageServiceMock);
   }
 
   /**
@@ -72,7 +71,6 @@ public final class SentimentServletTest {
     when(languageServiceMock.analyzeSentiment(any(Document.class)).getDocumentSentiment())
         .thenReturn(sentimentMock);
     when(sentimentMock.getScore()).thenReturn(SCORE);
-    doNothing().when(languageServiceMock).close();
 
     sentimentServlet.doGet(requestMock, responseSpy);
 
@@ -96,7 +94,6 @@ public final class SentimentServletTest {
     when(languageServiceMock.analyzeSentiment(any(Document.class)).getDocumentSentiment())
         .thenReturn(sentimentMock);
     when(sentimentMock.getScore()).thenReturn(SCORE);
-    doNothing().when(languageServiceMock).close();
 
     sentimentServlet.doGet(requestMock, responseSpy);
 
@@ -120,7 +117,6 @@ public final class SentimentServletTest {
     when(languageServiceMock.analyzeSentiment(any(Document.class)).getDocumentSentiment())
         .thenReturn(sentimentMock);
     when(sentimentMock.getScore()).thenReturn(SCORE);
-    doNothing().when(languageServiceMock).close();
 
     sentimentServlet.doGet(requestMock, responseSpy);
 
@@ -179,7 +175,6 @@ public final class SentimentServletTest {
     when(languageServiceMock.analyzeSentiment(any(Document.class)).getDocumentSentiment())
         .thenReturn(sentimentMock);
     when(sentimentMock.getScore()).thenReturn(SCORE);
-    doNothing().when(languageServiceMock).close();
 
     sentimentServlet.doGet(requestMock, responseSpy);
 

--- a/src/test/java/com/google/sps/SentimentServletTest.java
+++ b/src/test/java/com/google/sps/SentimentServletTest.java
@@ -40,13 +40,14 @@ public final class SentimentServletTest {
 
   @Spy HttpServletResponse responseSpy;
 
-  @InjectMocks SentimentServlet sentimentServlet;
+  @Spy @InjectMocks SentimentServlet sentimentServlet;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws IOException, Exception {
     stringWriter = new StringWriter();
     writer = new PrintWriter(stringWriter);
     when(responseSpy.getWriter()).thenReturn(writer);
+    when(sentimentServlet.createLanguageServiceClient()).thenReturn(languageServiceMock);
   }
 
   /**


### PR DESCRIPTION
Found a problem where you could not run ```doGet()``` in SentimentServlet and calculate the sentiment score more than once without shutting down the server and starting it up again. Realized it was caused by SentimentServlet having one instance of LanguageServiceClient that gets closed after ```calculateSentimentScore()``` is called the first time. 

Made changes to SentimentServlet and updated tests accordingly.