### PR TITLE
Accept Builder as the single VideoAnalysis constructor parameter

### DIFF
--- a/src/main/java/com/google/sps/data/VideoAnalysis.java
+++ b/src/main/java/com/google/sps/data/VideoAnalysis.java
@@ -18,20 +18,16 @@ public class VideoAnalysis {
     }
 
     public VideoAnalysis build() {
-      VideoAnalysis videoAnalysis = new VideoAnalysis();
-      videoAnalysis.score = this.score;
-      videoAnalysis.dataAvailable = this.dataAvailable;
-
-      return videoAnalysis;
+      return new VideoAnalysis(this);
     }
   }
 
-  private Float score;
-  private boolean dataAvailable;
+  private final Float score;
+  private final boolean dataAvailable;
 
-  private VideoAnalysis() {
-    this.score = score;
-    this.dataAvailable = dataAvailable;
+  private VideoAnalysis(Builder builder) {
+    this.score = builder.score;
+    this.dataAvailable = builder.dataAvailable;
   }
 
   public Float getScore() {
@@ -42,11 +38,7 @@ public class VideoAnalysis {
     return dataAvailable;
   }
 
-  public void setScore(Float score) {
-    this.score = score;
-  }
-
-  public void setDataAvailable(boolean dataAvailable) {
-    this.dataAvailable = dataAvailable;
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/src/main/java/com/google/sps/servlets/SentimentServlet.java
+++ b/src/main/java/com/google/sps/servlets/SentimentServlet.java
@@ -57,7 +57,7 @@ public class SentimentServlet extends HttpServlet {
     String captions = captionService.getCaptionFromId(videoId);
 
     if (comments.isEmpty() && captions.isEmpty()) {
-      VideoAnalysis videoAnalysis = new VideoAnalysis.Builder()
+      VideoAnalysis videoAnalysis = VideoAnalysis.builder()
           .setScore(null)
           .setDataAvailable(false)
           .build();
@@ -80,7 +80,7 @@ public class SentimentServlet extends HttpServlet {
       return;
     }
 
-    VideoAnalysis videoAnalysis = new VideoAnalysis.Builder()
+    VideoAnalysis videoAnalysis = VideoAnalysis.builder()
         .setScore(score)
         .setDataAvailable(true)
         .build();


### PR DESCRIPTION
This allows us to do all assignment to VideoAnalysis in the
constructor. So we can mark all our fields final and remove setters on
VideoAnalysis. It also allows us to avoid some assignments in the
VideoAnalysis constructor that always get overwritten during build.

reference: Effective Java item #2