### PR TITLE
Correct closing div tag

### DIFF
--- a/src/main/webapp/tests.html
+++ b/src/main/webapp/tests.html
@@ -12,7 +12,7 @@
   <div id="qunit"></div>
   <div id="qunit-fixture">
     <header></header>
-    <div id="menu"></menu>
+    <div id="menu"></div>
   </div>
   <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
   <script src="https://sinonjs.org/releases/sinon-9.0.0.js"></script>


### PR DESCRIPTION
The typo directly resulted in a missing closing div tag for `qunit-fixture`. This caused some asynchronous tests to fail, because the templates html for asynchronous functions don't do well in qunit-fixture.