### PR TITLE
Remove unused gapi fakes in tests

### DIFF
--- a/src/main/webapp/scripts/tests/comment-post-test.js
+++ b/src/main/webapp/scripts/tests/comment-post-test.js
@@ -1,11 +1,11 @@
 import { postVideoComment } from '/scripts/post-comment.js';
+import 'https://apis.google.com/js/api.js';
 
 const VIDEO_ID = 'sample video id';
 const COMMENT_TEXT = 'sample comment';
 
 QUnit.module('Post a comment via YouTube API', {
     beforeEach: () => {
-        gapi = new CustomGapi();
         sinon.stub(gapi.client, 'request');
     },
     afterEach: () => { gapi.client.request.restore(); },
@@ -64,17 +64,6 @@ class CustomError extends Error {
         super();
         this.result = { 'error': { 'message': msg, } };
     }
-}
-
-class CustomGapi {
-    constructor() {
-        this.client = new CustomClient();
-    }
-}
-
-class CustomClient {
-    constructor() { }
-    request() { }
 }
 
 function createExpectedRequestBody(videoId, commentText) {

--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -1,10 +1,8 @@
 import * as controller from '/scripts/controller-auth.js';
+import 'https://apis.google.com/js/api.js';
 
 // Test (controller-auth.js and) view.js
 QUnit.module('Authorization controller', {
-  beforeEach: () => {
-    gapi = new CustomGapi();
-  },
   afterEach: () => {
     sinon.restore();
   }
@@ -74,26 +72,7 @@ QUnit.test('When postVideoComment succeeds, the success message should be displa
 });
 
 
-
 // Helper functions and classes
-class CustomGapi {
-  constructor() {
-    this.client = new CustomClient();
-    this.auth2 = new Auth2();
-  }
-}
-
-class Auth2 {
-  constructor() { }
-  getAuthInstance() { }
-}
-
-class CustomClient {
-  constructor() { }
-  request() { }
-  init() { }
-}
-
 class CustomResponse extends Response {
   constructor() {
     super();

--- a/src/main/webapp/tests.html
+++ b/src/main/webapp/tests.html
@@ -15,6 +15,7 @@
     <div id="menu"></div>
   </div>
   <script src="https://code.jquery.com/qunit/qunit-2.10.0.js"></script>
+  <script src="https://unpkg.com/qunit-dom/dist/qunit-dom.js"></script>
   <script src="https://sinonjs.org/releases/sinon-9.0.0.js"></script>
   <script src="scripts/script.js"></script>
   <script src="scripts/perspective.js"></script>
@@ -22,8 +23,6 @@
   <script src="scripts/classes/comment-class.js"></script>
   <script src="scripts/tests/perspective-test.js"></script>
   <script src="scripts/tests/view-test.js"></script>
-  <script src="https://apis.google.com/js/api.js"></script>
-  <script src="https://unpkg.com/qunit-dom/dist/qunit-dom.js"></script>
   <script defer type="module" src="scripts/tests/comment-post-test.js"></script>
   <script defer type="module" src="scripts/tests/controller-auth-test.js"></script>
 


### PR DESCRIPTION
The fake gapi objects that weren't used in stubbing gapi are removed. 

They were initially created to fix the 'Cannot stub non-existent own property init' when mocking `gapi.client.init` but now it's not a problem anymore. I haven't figured out exactly why but very likely I made some mistakes using sinon in the first attempt. 