### PR TITLE
Clear commentButtonContainer before appending button

### DIFF
--- a/src/main/webapp/scripts/tests/controller-auth-test.js
+++ b/src/main/webapp/scripts/tests/controller-auth-test.js
@@ -23,7 +23,7 @@ QUnit.test('When signed in, there should be sign-out and comment buttons', async
   await controller.initClient();
 
   assert.dom('#authorize-button').hasProperty('innerText', 'Sign out');
-  assert.dom('#comment-button').exists();
+  assert.dom('#comment-button').exists({ count: 1 });
 });
 
 QUnit.test('When signed out, there should be an authorization button', async function (assert) {

--- a/src/main/webapp/scripts/view.js
+++ b/src/main/webapp/scripts/view.js
@@ -35,10 +35,14 @@ function updateSigninStatus(isSignedIn, handleAuthClick, handleSignoutClick, han
         updateDom('Sign out', authorizeButton)
         authorizeButton.onclick = handleSignoutClick;
         const commentButton = document.createElement('button');
-        document.getElementById('comment-button-container').appendChild(commentButton);
         commentButton.id = 'comment-button';
         commentButton.innerText = 'Post a comment';
         commentButton.onclick = handleCommentClick;
+        const commentButtonContainer = document.getElementById('comment-button-container');
+        while (commentButtonContainer.firstChild) {
+            commentButtonContainer.removeChild(commentButtonContainer.firstChild);
+        }
+        commentButtonContainer.appendChild(commentButton);
     } else {
         updateDom('Authorize', authorizeButton);
         authorizeButton.onclick = handleAuthClick;


### PR DESCRIPTION
The tests revealed the bug that when the user signs in and out multiple times, there will be multiple comment buttons displayed with the same id. So the fix is to clear the container before appending the button. 