### PR TITLE
Fix NullPointerException in parsing caption

### DIFF
--- a/src/main/java/com/google/sps/servlets/Caption.java
+++ b/src/main/java/com/google/sps/servlets/Caption.java
@@ -1,10 +1,12 @@
 package com.google.sps.servlets;
 
+import java.io.Console;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -38,8 +40,11 @@ public class Caption {
     NodeList textDom = doc.getElementsByTagName("text");
     StringBuilder caption = new StringBuilder();
     for (int i = 0; i < textDom.getLength(); i++) {
-      caption.append(textDom.item(i).getFirstChild().getNodeValue());
-      caption.append(" ");
+      Node child = textDom.item(i).getFirstChild();
+      if (child != null) {
+        caption.append(textDom.item(i).getFirstChild().getNodeValue());
+        caption.append(" ");
+      }
     }
     return caption.toString().trim();
   }

--- a/src/test/java/com/google/sps/servlets/CaptionTest.java
+++ b/src/test/java/com/google/sps/servlets/CaptionTest.java
@@ -36,6 +36,13 @@ public final class CaptionTest {
       + "<text start=\"9.43\" dur=\"5.06\">line2</text>"
       + "<text start=\"14.49\" dur=\"5.03\">line3</text>" + "</transcript>";
 
+  final private String PROPER_XML_WITH_EMPTY_LINE =
+      "<?xml version=\"1.0\" encoding=\"utf-8\" ?><transcript>"
+          + "<text start=\"4.029\" dur=\"5.401\">line1</text>"
+          + "<text start=\"9.43\" dur=\"5.06\">line2</text>"
+          + "<text start=\"14.49\" dur=\"5.03\"></text>"
+          + "<text start=\"19.52\" dur=\"5.00\">line3</text>" + "</transcript>";
+
   final private String PROPER_XML_CAPTION = "line1 line2 line3";
 
   final private String BAD_XML = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><transcript>"
@@ -56,6 +63,16 @@ public final class CaptionTest {
   @Test
   public void properXmlReturnsConcatenatedString() throws IOException {
     InputStream stream = new ByteArrayInputStream(PROPER_XML.getBytes());
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+
+    String actual = caption.getCaptionFromId(VIDEO_ID);
+
+    assertEquals(PROPER_XML_CAPTION, actual);
+  }
+
+  @Test
+  public void ignoreEmptyLineInXmlInConcatenatedString() throws IOException {
+    InputStream stream = new ByteArrayInputStream(PROPER_XML_WITH_EMPTY_LINE.getBytes());
     when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
 
     String actual = caption.getCaptionFromId(VIDEO_ID);


### PR DESCRIPTION
@kayefung points out that Caption.getCaptionFromId() throws uncaught NullPointerException for some videos (https://www.youtube.com/watch?v=X-euQU-WcJY for example) caused by this line:

```
caption.append(textDom.item(i).getFirstChild().getNodeValue());
```

This is because some text dom items are empty, so `.getFirstChild()` returns null.

```
<text start="133.07" dur="1.2">WOMAN 4: I&#39;m joking! I&#39;m joking!</text>
<text start="134.27" dur="1.22"/> // This line will cause the NullPointerException
``` 

The current fix is to wrap it with try-catch block. 