### PR TITLE
Extension: add context menu items and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-Capstone Project for STEP Program
+# Capstone Project for STEP Program
+This is a website (https://step70-2020.appspot.com/) that allows you to check the vibe of a YouTube video, and the toxicity of a comment.  A future feature is a chrome extension that incorporates these functions. 
+
+### How to load the dev chrome extension
+1. Go to chrome://extensions/ 
+2. Enable "Developer mode"
+3. "Load unpacked" the extension folder
+4. Reload the extension with "Update" button or "Refresh" button 
+
+### How to use the chrome extension
+1. Select any text, right click and select "check toxicity"
+2. Hover over any YouTube video, right click and select "check vibe" 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,12 +1,89 @@
-chrome.runtime.onInstalled.addListener(function() {
-  chrome.declarativeContent.onPageChanged.removeRules(undefined, function() { // undefined removes all rules
+const MS_BEFORE_CLEAR_NOTIFICAITON = 2000;
+const VIBE_CHECK_MENU_ID = 'vibeCheck';
+const TOXICITY_CHECK_MENU_ID = 'toxicityCheck';
+const ICON_PATH = '/images/temp-icon.png';
+
+chrome.runtime.onInstalled.addListener(function () {
+  // "undefined" removes all rules
+  chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
     chrome.declarativeContent.onPageChanged.addRules([{
       // required conditions for the extension to be active
       conditions: [new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: {hostEquals: 'www.youtube.com'},
+        pageUrl: { hostEquals: 'www.youtube.com' },
       })],
       // things to do if the extension is active
       actions: [new chrome.declarativeContent.ShowPageAction()]
     }]);
   });
 });
+
+chrome.runtime.onInstalled.addListener(function () {
+  const createProperties = {
+    'id': VIBE_CHECK_MENU_ID,
+    'title': 'Vibe check this video',
+    'contexts': ['link'],
+  };
+
+  chrome.contextMenus.create(createProperties);
+});
+
+chrome.runtime.onInstalled.addListener(function () {
+  const createProperties = {
+    'id': TOXICITY_CHECK_MENU_ID,
+    'title': 'Toxicity check this line',
+    'contexts': ['selection'],
+  };
+
+  chrome.contextMenus.create(createProperties);
+});
+
+chrome.contextMenus.onClicked.addListener(async function (info) {
+  if (info.menuItemId == VIBE_CHECK_MENU_ID) {
+    await handleVibeCheck(info);
+  } else if (info.menuItemId == TOXICITY_CHECK_MENU_ID) {
+    await handleToxicityCheck(info);
+  }
+});
+
+async function handleVibeCheck(info) {
+  const notificationOption = {
+    type: 'basic',
+    iconUrl: ICON_PATH,
+    title: await getSentimentAnaylsisMsg(info.linkUrl),
+    message: `Click to watch ${info.linkUrl}`,
+    priority: 0
+  };
+
+  chrome.notifications.create(notificationOption, function (id) {
+    chrome.notifications.onClicked.addListener(function () {
+      chrome.tabs.create({ url: info.linkUrl });
+    });
+    setTimeout(function () { chrome.notifications.clear(id); }, MS_BEFORE_CLEAR_NOTIFICAITON);
+  });
+}
+
+async function handleToxicityCheck(info) {
+  const notificationOption = {
+    type: 'basic',
+    iconUrl: ICON_PATH,
+    title: await getToxicityAnaylsisMsg(info.selectionText),
+    message: `"${info.selectionText}"`,
+    priority: 0
+  };
+
+  chrome.notifications.create(notificationOption, function (id) {
+    setTimeout(function () { chrome.notifications.clear(id); }, MS_BEFORE_CLEAR_NOTIFICAITON);
+  });
+}
+
+/**  @param {String} linkUrl, unchecked */
+async function getSentimentAnaylsisMsg(linkUrl) {
+  // TODO calls backend
+  return 'Sentiment score is 42';
+}
+
+/**  @param {String} text, unchecked */
+async function getToxicityAnaylsisMsg(text) {
+  // TODO calls backend
+  return 'Toxicity score is 24';
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -6,7 +6,9 @@
     "activeTab",
     "storage",
     "declarativeContent",
-    "tabs"
+    "tabs",
+    "contextMenus",
+    "notifications"
   ],
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
This chrome extension allows the user to check the video vibe and comment toxicity with Chrome's own context menu and notification. It reduces the friction to use our service because the user no longer needs to copy the link or text, open our website and then analyze. 

The chrome extension will be connected to our backend in a later PR. Currently the handler always returns the same string. 

Thank you @nif33 for setting up the chrome extension files and sharing your notes. 