### PR TITLE
Use threads and invokeAny to get captions faster

### DIFF
--- a/src/main/java/com/google/sps/servlets/Caption.java
+++ b/src/main/java/com/google/sps/servlets/Caption.java
@@ -1,8 +1,14 @@
 package com.google.sps.servlets;
 
-import java.io.Console;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.concurrent.ExecutionException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
@@ -23,15 +29,26 @@ public class Caption {
   public String getCaptionFromId(String videoId) {
     // BCP47 language tags
     final String[] languages = {"en", "en-US", "en-GB", "en-AU", "en-IE", "en-ZA"};
-    for (String language : languages) {
-      try {
-        return parseXmlFromStream(captionService.fetchStream(videoId, language));
-      } catch (SAXException | ParserConfigurationException | IOException
-          | IllegalArgumentException e) {
-        continue;
-      }
+
+    ExecutorService executor = Executors.newFixedThreadPool(languages.length);
+
+    List<Callable<String>> captionCallables =
+        Arrays.stream(languages).map(language -> new Callable<String>() {
+          @Override
+          public String call() throws Exception {
+            return parseXmlFromStream(captionService.fetchStream(videoId, language));
+          }
+        }).collect(Collectors.toList());
+
+    String caption = "";
+    try {
+      caption = executor.invokeAny(captionCallables);
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    } finally {
+      executor.shutdown();
     }
-    return "";
+    return caption;
   }
 
   private String parseXmlFromStream(InputStream inputStream)
@@ -48,4 +65,5 @@ public class Caption {
     }
     return caption.toString().trim();
   }
+
 }

--- a/src/test/java/com/google/sps/servlets/CaptionTest.java
+++ b/src/test/java/com/google/sps/servlets/CaptionTest.java
@@ -22,6 +22,9 @@ import org.junit.runners.JUnit4;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public final class CaptionTest {
@@ -62,8 +65,8 @@ public final class CaptionTest {
 
   @Test
   public void properXmlReturnsConcatenatedString() throws IOException {
-    InputStream stream = new ByteArrayInputStream(PROPER_XML.getBytes());
-    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN)))
+        .thenAnswer(invocation -> new ByteArrayInputStream(PROPER_XML.getBytes()));
 
     String actual = caption.getCaptionFromId(VIDEO_ID);
 
@@ -72,8 +75,8 @@ public final class CaptionTest {
 
   @Test
   public void ignoreEmptyLineInXmlInConcatenatedString() throws IOException {
-    InputStream stream = new ByteArrayInputStream(PROPER_XML_WITH_EMPTY_LINE.getBytes());
-    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN)))
+        .thenAnswer(invocation -> new ByteArrayInputStream(PROPER_XML_WITH_EMPTY_LINE.getBytes()));
 
     String actual = caption.getCaptionFromId(VIDEO_ID);
 
@@ -82,8 +85,8 @@ public final class CaptionTest {
 
   @Test
   public void badXmlReturnsNullIgnoringSAXException() throws IOException {
-    InputStream stream = new ByteArrayInputStream(BAD_XML.getBytes());
-    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN))).thenReturn(stream);
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), contains(LANG_EN)))
+        .thenAnswer(invocation -> new ByteArrayInputStream(BAD_XML.getBytes()));
 
     String actual = caption.getCaptionFromId(VIDEO_ID);
 
@@ -92,8 +95,8 @@ public final class CaptionTest {
 
   @Test
   public void nonDefaultLanguageReturnsConcatenatedString() throws IOException {
-    InputStream stream = new ByteArrayInputStream(PROPER_XML.getBytes());
-    when(captionServiceMock.fetchStream(eq(VIDEO_ID), eq(LANG_EN_GB))).thenReturn(stream);
+    when(captionServiceMock.fetchStream(eq(VIDEO_ID), eq(LANG_EN_GB)))
+        .thenAnswer(invocation -> new ByteArrayInputStream(PROPER_XML.getBytes()));
     when(captionServiceMock.fetchStream(eq(VIDEO_ID), not(eq(LANG_EN_GB))))
         .thenThrow(new IOException());
 


### PR DESCRIPTION
@nif33 suggested that using threads to fetch 6 captions of the same video is faster than doing so consecutively. It is implemented here. Time taken to access captions for one video is reduced from ~2000ms to ~400ms in my experiments. 

Two tests are unstable (run tests: `mvn clean && mvn test`). As @kayefung suggested, further specifying the setup can ensure the tests to pass. What I don't understand is why the original tests become flaky once threads are introduced. 

EDIT:
When the flaky tests fail, it is due to the `ExecutionException` thrown by invokeAny, which indicates *none* of the tasks complete successfully. However, the original set up should allow *all* tasks to finish. 

`ExecutionException` is caused by `SAXParseException@67 "org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 10; White space is required between the processing instruction target and data."` my current guess is Stream/DocumentBuilder is not threadsafe. 

RESOLVED:
It turns out the issue isn't even related to threads -- the inputstreams returned by the mocks in the tests are not reusable. The SAXParseException is thrown by every caller when all of them try to parse the same inputstream simultaneously. The fix is instead of `thenReturn`, create a new inputstream with `thenAnswer`, so every caller gets their own copy. This has been an undiscovered bug. 