### PR TITLE
Fix flaky test in SentimentServletTest by stubbing return values for specific inputs

### DIFF
--- a/src/test/java/com/google/sps/SentimentServletTest.java
+++ b/src/test/java/com/google/sps/SentimentServletTest.java
@@ -116,10 +116,9 @@ public final class SentimentServletTest {
     when(requestMock.getParameter("video-id")).thenReturn(VIDEO_ID);
     when(commentServiceMock.getCommentsFromId(VIDEO_ID)).thenReturn(comments);
     when(captionServiceMock.getCaptionFromId(VIDEO_ID)).thenReturn(captions);
-    when(sentimentAnalysisMock.calculateSentimentScore(anyString()))
-        .thenReturn(SCORE_0)
-        .thenReturn(SCORE_1)
-        .thenReturn(SCORE_2);
+    when(sentimentAnalysisMock.calculateSentimentScore("foo")).thenReturn(SCORE_0);
+    when(sentimentAnalysisMock.calculateSentimentScore("bar")).thenReturn(SCORE_1);
+    when(sentimentAnalysisMock.calculateSentimentScore("foobar")).thenReturn(SCORE_2);
 
     sentimentServlet.doGet(requestMock, responseSpy);
 


### PR DESCRIPTION
@nif33 discovered that ```onlyCommentsPrintsVideoAnalysisJsonObject()``` in SentimentServletTest was flaky. Originally I was returning score 0 for the first call to the ```calculateSentimentScore()```, then score 1 for the second call, and score 2 for the third call. With the addition of multithreading in PR #26, different inputs would sometimes return the same score and then the assertion at the end of the test would fail. 
I don't really have time to delve into why exactly this is happening but a quick solution is to return specific sentiment scores for specific inputs (ex, ```when(sentimentAnalysisMock.calculateSentimentScore("foo")).thenReturn(SCORE_0);```)